### PR TITLE
fix(tailwind.config.js): corrent minHeight and minWidth

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,12 +75,13 @@ module.exports = {
         6: "6px",
         8: "8px",
       },
-      minHeight: {
-        ...defaultTheme.height,
-      },
-      minWidth: {
-        ...defaultTheme.width,
-      },
+      minHeight: ({theme}) => ({
+        ...theme('height'),
+      }),
+      minWidth: ({theme}) => ({
+        ...theme('width'),
+      }),
+
     },
   },
   plugins: [],


### PR DESCRIPTION
I debug `yarn dev`, and found that the way to get the right minHeight/minWidth is to use function